### PR TITLE
Rewrite to class syntax

### DIFF
--- a/metawatch.js
+++ b/metawatch.js
@@ -2,27 +2,50 @@
 
 const fs = require('fs');
 const path = require('path');
+const { EventEmitter } = require('events');
 
-const watch = (targetPath, listener) => {
-  fs.readdir(targetPath, { withFileTypes: true }, (err, files) => {
-    for (const file of files) {
-      if (file.isDirectory()) {
-        const dirPath = path.join(targetPath, file.name);
-        watch(dirPath, listener);
-      }
-    }
-    fs.watch(targetPath, (event, fileName) => {
+class DirectoryWatcher extends EventEmitter {
+  constructor() {
+    super();
+    this.watchers = new Map();
+  }
+
+  watchDirectory(targetPath) {
+    if (this.watchers.get(targetPath)) return;
+    const watcher = fs.watch(targetPath, (event, fileName) => {
       const filePath = path.join(targetPath, fileName);
       try {
         fs.stat(filePath, (err, stats) => {
-          if (stats.isDirectory()) watch(filePath, listener);
+          if (stats.isDirectory()) this.watch(filePath);
         });
       } catch {
         return;
       }
-      listener(event, fileName);
+      this.emit(event, fileName);
     });
-  });
-};
+    this.watchers.set(targetPath, watcher);
+  }
 
-module.exports = watch;
+  watch(targetPath) {
+    const watcher = this.watchers[targetPath];
+    if (watcher) return;
+    fs.readdir(targetPath, { withFileTypes: true }, (err, files) => {
+      for (const file of files) {
+        if (file.isDirectory()) {
+          const dirPath = path.join(targetPath, file.name);
+          this.watch(dirPath);
+        }
+      }
+      this.watchDirectory(targetPath);
+    });
+  }
+
+  unwatch(path) {
+    const watcher = this.watchers[path];
+    if (!watcher) return;
+    watcher.close();
+    this.watchers.delete(path);
+  }
+}
+
+module.exports = { DirectoryWatcher };

--- a/test/unit.js
+++ b/test/unit.js
@@ -14,7 +14,7 @@ const dir = process.cwd();
 const targetPath = path.join(dir, 'test/example');
 
 metatests.test('Watch file change ', test => {
-  test.strictSame(typeof metawatch, 'function');
+  test.strictSame(typeof metawatch, 'object');
 
   const timeout = setTimeout(() => {
     test.fail();
@@ -23,9 +23,10 @@ metatests.test('Watch file change ', test => {
   let count = 0;
   const expected = process.platform === 'darwin' ? 1 : 2;
 
-  metawatch(targetPath, (event, fileName) => {
+  const watcher = new metawatch.DirectoryWatcher();
+  watcher.watch(targetPath);
+  watcher.on('change', (fileName) => {
     count++;
-    test.strictSame(event, 'change');
     test.strictSame(fileName, 'file.ext');
     clearTimeout(timeout);
     if (count === expected) {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
