### PR TITLE
Optimize queue, use Set instead of two arrays

### DIFF
--- a/metawatch.js
+++ b/metawatch.js
@@ -12,8 +12,7 @@ class DirectoryWatcher extends EventEmitter {
     this.watchers = new Map();
     this.timeout = options.timeout || WATCH_TIMEOUT;
     this.timer = null;
-    this.queue = [];
-    this.index = [];
+    this.queue = new Map();
   }
 
   post(event, filePath) {
@@ -21,21 +20,17 @@ class DirectoryWatcher extends EventEmitter {
     this.timer = setTimeout(() => {
       this.sendQueue();
     }, this.timeout);
-    const key = event + ':' + filePath;
-    if (this.index.includes(key)) return;
-    this.queue.push({ event, filePath });
-    this.index.push(key);
+    this.queue.set(filePath, event);
   }
 
   sendQueue() {
     if (!this.timer) return;
     clearTimeout(this.timer);
     this.timer = null;
-    for (const item of this.queue) {
-      this.emit(item.event, item.filePath);
+    for (const [filePath, event] of this.queue) {
+      this.emit(event, filePath);
     }
-    this.queue = [];
-    this.index = [];
+    this.queue.clear();
   }
 
   watchDirectory(targetPath) {

--- a/types/metawatch.d.ts
+++ b/types/metawatch.d.ts
@@ -5,8 +5,7 @@ export class DirectoryWatcher extends EventEmitter {
   watchers: Map<string, FSWatcher>;
   timeout: number;
   timer: NodeJS.Timer;
-  queue: Array<string>;
-  index: Array<string>;
+  queue: Map<string, string>;
   constructor(options?: { timeout?: number });
   post(event: string, fileName: string): void;
   sendQueue(): void;


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
